### PR TITLE
feat: extend user with avatar, description, email change token, create date. Add two endpoints to change email.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -340,3 +340,4 @@ ASALocalRun/
 healthchecksdb
 /.sonarqube
 /QuizyfyAPI/wwwroot/images/quizzes
+/.claudiaideconfig

--- a/QuizyfyAPI-Tests/ChoiceControllerTest.cs
+++ b/QuizyfyAPI-Tests/ChoiceControllerTest.cs
@@ -80,7 +80,7 @@ namespace QuizyfyAPI_Tests
             //Act
             var result = await _choiceController.Get(1, 2);
 
-            //Assert
+            //Assert 
             Assert.IsType<NotFoundResult>(result.Result);
         }
 

--- a/QuizyfyAPI/Contracts/Requests/ChangeEmailRequest.cs
+++ b/QuizyfyAPI/Contracts/Requests/ChangeEmailRequest.cs
@@ -1,0 +1,11 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace QuizyfyAPI.Contracts.Requests
+{
+    public class ChangeEmailRequest
+    {
+        [EmailAddress]
+        public string NewEmail { get; set; } = null!;
+        public string Token { get; set; } = null!;
+    }
+}

--- a/QuizyfyAPI/Contracts/Requests/EmailChangeTokenGenerationRequest.cs
+++ b/QuizyfyAPI/Contracts/Requests/EmailChangeTokenGenerationRequest.cs
@@ -1,0 +1,10 @@
+﻿using System.ComponentModel.DataAnnotations;
+
+namespace QuizyfyAPI.Contracts.Requests
+{
+    public class EmailChangeTokenGenerationRequest
+    {
+        [EmailAddress]
+        public string NewEmail { get; set; } = null!;
+    }
+}

--- a/QuizyfyAPI/Contracts/Requests/UserUpdateRequest.cs
+++ b/QuizyfyAPI/Contracts/Requests/UserUpdateRequest.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel.DataAnnotations;
+﻿using QuizyfyAPI.Data;
+using System.ComponentModel.DataAnnotations;
 
 namespace QuizyfyAPI.Contracts.Requests;
 /// <summary>
@@ -20,6 +21,16 @@ public class UserUpdateRequest
     /// User name.
     /// </summary>
     public string? Username { get; set; }
+
+    /// <summary>
+    /// Description of a user.
+    /// </summary>
+    public string? Description { get; set; }
+
+    /// <summary>
+    /// Avatar image of a user.
+    /// </summary>
+    public Image? Image { get; set; }
 
     /// <summary>
     /// User password.

--- a/QuizyfyAPI/Contracts/Responses/UserResponse.cs
+++ b/QuizyfyAPI/Contracts/Responses/UserResponse.cs
@@ -7,6 +7,7 @@ namespace QuizyfyAPI.Contracts.Responses;
 /// </summary>
 public class UserResponse
 {
+    public int Id { get; set; }
     /// <summary>
     /// First name of the user owner.
     /// </summary>
@@ -16,6 +17,11 @@ public class UserResponse
     /// Last name of the user owner.
     /// </summary>
     public string LastName { get; set; }
+
+    /// <summary>
+    /// Description of a user.
+    /// </summary>
+    public string Description { get; set; }
 
     /// <summary>
     /// User name.

--- a/QuizyfyAPI/Data/Entities/Interfaces/ICreatedDate.cs
+++ b/QuizyfyAPI/Data/Entities/Interfaces/ICreatedDate.cs
@@ -1,0 +1,7 @@
+﻿namespace QuizyfyAPI.Data.Entities.Interfaces
+{
+    public interface ICreatedDate
+    {
+        DateTime CreatedDate { get; set; }
+    }
+}

--- a/QuizyfyAPI/Data/Entities/User.cs
+++ b/QuizyfyAPI/Data/Entities/User.cs
@@ -1,8 +1,10 @@
-﻿namespace QuizyfyAPI.Data;
+﻿using QuizyfyAPI.Data.Entities.Interfaces;
+
+namespace QuizyfyAPI.Data;
 /// <summary>
 /// A User model, which is a representation of row from Users table.
 /// </summary>
-public class User
+public class User : ICreatedDate
 {
     /// <summary>
     /// Id of a user.
@@ -20,6 +22,14 @@ public class User
     /// Made up username.
     /// </summary>
     public string Username { get; set; } = null!;
+    /// <summary>
+    /// Avatar image of a user.
+    /// </summary>
+    public Image? Avatar { get; set; }
+    /// <summary>
+    /// Description of a user.
+    /// </summary>
+    public string? Description { get; set; }
     /// <summary>
     /// Password in a hashed form.
     /// </summary>
@@ -56,4 +66,12 @@ public class User
     /// Token used for password recovery.
     /// </summary>
     public string? RecoveryToken { get; set; }
+    /// <summary>
+    /// Token used to change email.
+    /// </summary>
+    public string? EmailChangeToken { get; set; }
+    /// <summary>
+    /// Date which represents when user was created.
+    /// </summary>
+    public DateTime CreatedDate { get; set; }
 }

--- a/QuizyfyAPI/Data/QuizDbContext.cs
+++ b/QuizyfyAPI/Data/QuizDbContext.cs
@@ -1,4 +1,5 @@
 ﻿using Microsoft.EntityFrameworkCore;
+using QuizyfyAPI.Data.Entities.Interfaces;
 
 namespace QuizyfyAPI.Data;
 public class QuizDbContext : DbContext
@@ -14,4 +15,34 @@ public class QuizDbContext : DbContext
     public DbSet<Like> Likes => Set<Like>();
     public DbSet<Image> Images => Set<Image>();
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
+
+    public override int SaveChanges()
+    {
+        SetProperties();
+        return base.SaveChanges();
+    }
+
+    public override Task<int> SaveChangesAsync(bool acceptAllChangesOnSuccess, CancellationToken cancellationToken = default)
+    {
+        SetProperties();
+        return base.SaveChangesAsync(acceptAllChangesOnSuccess, cancellationToken);
+    }
+
+    public override Task<int> SaveChangesAsync(CancellationToken cancellationToken = default)
+    {
+        SetProperties();
+        return base.SaveChangesAsync(cancellationToken);
+    }
+
+    private void SetProperties()
+    {
+        foreach (var entity in ChangeTracker.Entries().Where(p => p.State == EntityState.Added))
+        {
+            var created = entity.Entity as ICreatedDate;
+            if (created != null)
+            {
+                created.CreatedDate = DateTime.Now;
+            }
+        }
+    }
 }

--- a/QuizyfyAPI/Data/UserProfile.cs
+++ b/QuizyfyAPI/Data/UserProfile.cs
@@ -13,5 +13,7 @@ public class UserProfile : Profile
         CreateMap<UserResponse, UserRegisterRequest>().ReverseMap();
         CreateMap<User, UserLoginRequest>().ReverseMap();
         CreateMap<UserResponse, UserLoginRequest>().ReverseMap();
+
+        CreateMap<UserUpdateRequest, User>().ForAllMembers(opt => opt.Condition((src, dest, sourceMember) => sourceMember != null));
     }
 }

--- a/QuizyfyAPI/ExtensionMethods.cs
+++ b/QuizyfyAPI/ExtensionMethods.cs
@@ -22,5 +22,20 @@ namespace QuizyfyAPI
             }
             return webhost;
         }
+
+        static System.Text.Encoding ISO_8859_1_ENCODING = System.Text.Encoding.GetEncoding("ISO-8859-1");
+        public static (string, string) GetUsernameAndPasswordFromAuthorizeHeader(string authorizeHeader)
+        {
+            if (authorizeHeader == null || !authorizeHeader.Contains("Basic "))
+                return (string.Empty, string.Empty);
+
+            string encodedUsernamePassword = authorizeHeader.Substring("Basic ".Length).Trim();
+            string usernamePassword = ISO_8859_1_ENCODING.GetString(Convert.FromBase64String(encodedUsernamePassword));
+
+            string username = usernamePassword.Split(':')[0];
+            string password = usernamePassword.Split(':')[1];
+
+            return (username, password);
+        }
     }
 }

--- a/QuizyfyAPI/Migrations/20220408115352_Extend user with avatar, description and created date.Designer.cs
+++ b/QuizyfyAPI/Migrations/20220408115352_Extend user with avatar, description and created date.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QuizyfyAPI.Data;
 
@@ -11,9 +12,10 @@ using QuizyfyAPI.Data;
 namespace QuizyfyAPI.Migrations
 {
     [DbContext(typeof(QuizDbContext))]
-    partial class QuizDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220408115352_Extend user with avatar, description and created date")]
+    partial class Extenduserwithavatardescriptionandcreateddate
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -193,9 +195,6 @@ namespace QuizyfyAPI.Migrations
 
                     b.Property<string>("Email")
                         .IsRequired()
-                        .HasColumnType("nvarchar(max)");
-
-                    b.Property<string>("EmailChangeToken")
                         .HasColumnType("nvarchar(max)");
 
                     b.Property<bool>("EmailConfirmed")

--- a/QuizyfyAPI/Migrations/20220408115352_Extend user with avatar, description and created date.cs
+++ b/QuizyfyAPI/Migrations/20220408115352_Extend user with avatar, description and created date.cs
@@ -1,0 +1,66 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QuizyfyAPI.Migrations
+{
+    public partial class Extenduserwithavatardescriptionandcreateddate : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<int>(
+                name: "AvatarId",
+                table: "Users",
+                type: "int",
+                nullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "CreatedDate",
+                table: "Users",
+                type: "datetime2",
+                nullable: false,
+                defaultValue: new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified));
+
+            migrationBuilder.AddColumn<string>(
+                name: "Description",
+                table: "Users",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_Users_AvatarId",
+                table: "Users",
+                column: "AvatarId");
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_Users_Images_AvatarId",
+                table: "Users",
+                column: "AvatarId",
+                principalTable: "Images",
+                principalColumn: "Id");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_Users_Images_AvatarId",
+                table: "Users");
+
+            migrationBuilder.DropIndex(
+                name: "IX_Users_AvatarId",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "AvatarId",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "CreatedDate",
+                table: "Users");
+
+            migrationBuilder.DropColumn(
+                name: "Description",
+                table: "Users");
+        }
+    }
+}

--- a/QuizyfyAPI/Migrations/20220413104943_Extend user with email change token.Designer.cs
+++ b/QuizyfyAPI/Migrations/20220413104943_Extend user with email change token.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using QuizyfyAPI.Data;
 
@@ -11,9 +12,10 @@ using QuizyfyAPI.Data;
 namespace QuizyfyAPI.Migrations
 {
     [DbContext(typeof(QuizDbContext))]
-    partial class QuizDbContextModelSnapshot : ModelSnapshot
+    [Migration("20220413104943_Extend user with email change token")]
+    partial class Extenduserwithemailchangetoken
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/QuizyfyAPI/Migrations/20220413104943_Extend user with email change token.cs
+++ b/QuizyfyAPI/Migrations/20220413104943_Extend user with email change token.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace QuizyfyAPI.Migrations
+{
+    public partial class Extenduserwithemailchangetoken : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "EmailChangeToken",
+                table: "Users",
+                type: "nvarchar(max)",
+                nullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmailChangeToken",
+                table: "Users");
+        }
+    }
+}

--- a/QuizyfyAPI/Options/SendGridOptions.cs
+++ b/QuizyfyAPI/Options/SendGridOptions.cs
@@ -9,6 +9,8 @@ public class SendGridOptions
     public MailInfo RegistrationInfo { get; set; } = null!;
     [Required]
     public MailInfo PasswordResetInfo { get; set; } = null!;
+    [Required]
+    public MailInfo EmailChangeInfo { get; set; } = null!;
 }
 
 public class MailInfo

--- a/QuizyfyAPI/ServiceExtensions.cs
+++ b/QuizyfyAPI/ServiceExtensions.cs
@@ -43,7 +43,7 @@ public static class ServiceExtensions
             ValidateAudience = jwtOptions.ValidateAudience,
             ValidateLifetime = jwtOptions.ValidateLifetime,
             RequireExpirationTime = jwtOptions.RequireExpirationTime,
-            ClockSkew = TimeSpan.Zero,
+            ClockSkew = TokenValidationParameters.DefaultClockSkew
         };
 
         services.AddSingleton(tokenValidationParameters);
@@ -61,7 +61,7 @@ public static class ServiceExtensions
                 OnTokenValidated = async (context) =>
                 {
                     var userService = context.HttpContext.RequestServices.GetRequiredService<IUserRepository>();                    
-                    var userId = context.Principal?.Identity?.Name?.ParseToNullableInt();
+                    var userId = context.Principal?.Claims.FirstOrDefault(claim => claim.Type == "Id")?.Value.ParseToNullableInt();
 
                     if (await userService.GetUserById(userId) == null)
                     {

--- a/QuizyfyAPI/Services/Interfaces/ISendGridService.cs
+++ b/QuizyfyAPI/Services/Interfaces/ISendGridService.cs
@@ -6,4 +6,5 @@ public interface ISendGridService
 {
     Task<Response> SendConfirmationEmailTo(User user);
     Task<Response> SendPasswordResetEmailTo(User user);
+    Task<Response> SendChangeEmailTo(User user, string newEmail);
 }

--- a/QuizyfyAPI/Services/Interfaces/IUserService.cs
+++ b/QuizyfyAPI/Services/Interfaces/IUserService.cs
@@ -9,10 +9,13 @@ public interface IUserService : IService
     Task<ObjectResult<UserResponse>> Login(UserLoginRequest request);
     Task<BasicResult> Register(UserRegisterRequest request);
     Task<ObjectResult<UserResponse>> Update(int userId, UserUpdateRequest request);
+    Task<bool> Authenticate(string username, string password);
     Task<DetailedResult> Delete(int userId);
     Task<ObjectResult<UserResponse>> VerifyEmail(int userId, string token);
     Task<ObjectResult<UserResponse>> RecoverPassword(int userId, string token, string password);
+    Task<ObjectResult<UserResponse>> ChangeEmail (int userId, string token, string newEmail);
     Task<ObjectResult<UserResponse>> GenerateRecoveryToken(RecoveryTokenGenerationRequest request);
+    Task<ObjectResult<UserResponse>> GenerateEmailChangeToken (int userId, EmailChangeTokenGenerationRequest request); 
     Task<ObjectResult<UserResponse>> RefreshTokenAsync(UserRefreshRequest request);
     Task<User> RequestToken(User user);
 }

--- a/QuizyfyAPI/Services/SendGridService.cs
+++ b/QuizyfyAPI/Services/SendGridService.cs
@@ -9,7 +9,6 @@ public class SendGridService : ISendGridService
 {
     private readonly ISendGridClient _sendGridClient;
     private readonly SendGridOptions _sendGridOptions;
-
     public SendGridService(ISendGridClient sendGridClient, IOptions<SendGridOptions> sendGridOptions)
     {
         _sendGridClient = sendGridClient;
@@ -34,6 +33,17 @@ public class SendGridService : ISendGridService
         var subject = _sendGridOptions.PasswordResetInfo.Subject;
         var plainContent = _sendGridOptions.PasswordResetInfo.PlainContent;
         var htmlContent = $"<a href='http://localhost:8080/resetPassword/{user.Id}/{user.RecoveryToken}'>Zresetuj hasło.</a>";
+        var email = MailHelper.CreateSingleEmail(from, to, subject, plainContent, htmlContent);
+        return _sendGridClient.SendEmailAsync(email);
+    }
+
+    public Task <Response> SendChangeEmailTo(User user, string newEmail)
+    {
+        var from = new EmailAddress(_sendGridOptions.HostEmail);
+        var to = new EmailAddress(newEmail);
+        var subject = _sendGridOptions.EmailChangeInfo.Subject;
+        var plainContent = _sendGridOptions.EmailChangeInfo.PlainContent;
+        var htmlContent = $"<a href='http://localhost:8080/changeEmail?id={user.Id}&emailChangeToken={user.EmailChangeToken}&email={newEmail}'>Zmień adres e-mail.</a>";
         var email = MailHelper.CreateSingleEmail(from, to, subject, plainContent, htmlContent);
         return _sendGridClient.SendEmailAsync(email);
     }

--- a/QuizyfyAPI/appsettings.json
+++ b/QuizyfyAPI/appsettings.json
@@ -127,6 +127,11 @@
       "Subject": "Reset password on quizyfy!",
       "PlainContent": "Here is your link",
       "HtmlContent": "Here is your link"
+    },
+    "EmailChangeInfo": {
+      "Subject": "Change your Quizyfy email address",
+      "PlainContent": "Here is your link",
+      "HtmlContent": "Here is your link"
     }
   }
 }


### PR DESCRIPTION
This PR Closes #46 
New fields were added to the user model.
Two new endpoints were added on user controller to generate email change token and to change email.
Update delete, and put methods of the user were updated to take password passed via X-Authorization header to prevent the situation where the user would leave the computer enabled and someone would update or delete his account without knowing the password, as previously only JWT token was used for auth.